### PR TITLE
Updates for Jan 2023 publication

### DIFF
--- a/latex/hardware/citations.bib
+++ b/latex/hardware/citations.bib
@@ -205,18 +205,6 @@
   copyright = {Creative Commons Attribution Non Commercial No Derivatives 4.0 International}
 }
 
-@article{https://doi.org/10.48550/arxiv.2207.03189,
-  doi       = {10.48550/ARXIV.2207.03189},
-  url       = {https://arxiv.org/abs/2207.03189},
-  author    = {Amitrano, Valentina and Roggero, Alessandro and Luchi, Piero and Turro, Francesco and Vespucci, Luca and Pederiva, Francesco},
-  keywords  = {Quantum Physics (quant-ph), High Energy Physics - Theory (hep-th), Nuclear Theory (nucl-th), FOS: Physical sciences, FOS: Physical sciences},
-  title     = {Trapped-Ion Quantum Simulation of Collective Neutrino Oscillations},
-  publisher = {arXiv},
-  year      = {2022},
-  month     = {7},
-  copyright = {Creative Commons Attribution 4.0 International}
-}
-
 @article{https://doi.org/10.48550/arxiv.2207.14313,
   doi       = {10.48550/ARXIV.2207.14313},
   url       = {https://arxiv.org/abs/2207.14313},
@@ -399,4 +387,51 @@
   year      = {2022},
   month     = {12},
   copyright = {Creative Commons Attribution 4.0 International}
+}
+@article{https://doi.org/10.48550/arxiv.2301.11005,
+  doi       = {10.48550/ARXIV.2301.11005},
+  url       = {https://arxiv.org/abs/2301.11005},
+  author    = {Hegade, Narendra N. and Solano, Enrique},
+  keywords  = {Quantum Physics (quant-ph), Mesoscale and Nanoscale Physics (cond-mat.mes-hall), FOS: Physical sciences, FOS: Physical sciences},
+  title     = {Digitized-counterdiabatic quantum factorization},
+  publisher = {arXiv},
+  year      = {2023},
+  month     = {1},
+  copyright = {Creative Commons Attribution 4.0 International}
+}
+@article{https://doi.org/10.48550/arxiv.2301.07841,
+  doi       = {10.48550/ARXIV.2301.07841},
+  url       = {https://arxiv.org/abs/2301.07841},
+  author    = {Balewski, Jan and Amankwah, Mercy G. and Van Beeumen, Roel and Bethel, E. Wes and Perciano, Talita and Camps, Daan},
+  keywords  = {Quantum Physics (quant-ph), FOS: Physical sciences, FOS: Physical sciences},
+  title     = {Quantum-parallel vectorized data encodings and computations on trapped-ions and transmons QPUs},
+  publisher = {arXiv},
+  year      = {2023},
+  month     = {1},
+  copyright = {arXiv.org perpetual, non-exclusive license}
+}
+@article{https://doi.org/10.48550/arxiv.2301.05752,
+  doi       = {10.48550/ARXIV.2301.05752},
+  url       = {https://arxiv.org/abs/2301.05752},
+  author    = {Claudino, Daniel and Peng, Bo and Kowalski, Karol and Humble, Travis S.},
+  keywords  = {Quantum Physics (quant-ph), Chemical Physics (physics.chem-ph), FOS: Physical sciences, FOS: Physical sciences},
+  title     = {Modeling singlet fission on a quantum computer},
+  publisher = {arXiv},
+  year      = {2023},
+  month     = {1},
+  copyright = {Creative Commons Attribution 4.0 International}
+}
+@article{PhysRevD.107.023007,
+  title = {Trapped-ion quantum simulation of collective neutrino oscillations},
+  author = {Amitrano, Valentina and Roggero, Alessandro and Luchi, Piero and Turro, Francesco and Vespucci, Luca and Pederiva, Francesco},
+  journal = {Phys. Rev. D},
+  volume = {107},
+  issue = {2},
+  pages = {023007},
+  numpages = {15},
+  year = {2023},
+  month = {Jan},
+  publisher = {American Physical Society},
+  doi = {10.1103/PhysRevD.107.023007},
+  url = {https://link.aps.org/doi/10.1103/PhysRevD.107.023007}
 }

--- a/latex/hardware/citations.bib
+++ b/latex/hardware/citations.bib
@@ -229,21 +229,6 @@
   copyright = {Creative Commons Attribution 4.0 International}
 }
 
-@article{PhysRevD.106.114515,
-  title     = {Quantum simulation of the $N$-flavor Gross-Neveu model},
-  author    = {Asaduzzaman, Muhammad and Toga, Goksu Can and Catterall, Simon and Meurice, Yannick and Sakai, Ryo},
-  journal   = {Phys. Rev. D},
-  volume    = {106},
-  issue     = {11},
-  pages     = {114515},
-  numpages  = {11},
-  year      = {2022},
-  month     = {12},
-  publisher = {American Physical Society},
-  doi       = {10.1103/PhysRevD.106.114515},
-  url       = {https://link.aps.org/doi/10.1103/PhysRevD.106.114515}
-}
-
 @article{https://doi.org/10.48550/arxiv.2209.09371,
   doi       = {10.48550/ARXIV.2209.09371},
   url       = {https://arxiv.org/abs/2209.09371},
@@ -388,6 +373,22 @@
   month     = {12},
   copyright = {Creative Commons Attribution 4.0 International}
 }
+
+@article{PhysRevD.106.114515,
+  title     = {Quantum simulation of the $N$-flavor Gross-Neveu model},
+  author    = {Asaduzzaman, Muhammad and Toga, Goksu Can and Catterall, Simon and Meurice, Yannick and Sakai, Ryo},
+  journal   = {Phys. Rev. D},
+  volume    = {106},
+  issue     = {11},
+  pages     = {114515},
+  numpages  = {11},
+  year      = {2022},
+  month     = {12},
+  publisher = {American Physical Society},
+  doi       = {10.1103/PhysRevD.106.114515},
+  url       = {https://link.aps.org/doi/10.1103/PhysRevD.106.114515}
+}
+
 @article{https://doi.org/10.48550/arxiv.2301.11005,
   doi       = {10.48550/ARXIV.2301.11005},
   url       = {https://arxiv.org/abs/2301.11005},
@@ -399,6 +400,7 @@
   month     = {1},
   copyright = {Creative Commons Attribution 4.0 International}
 }
+
 @article{https://doi.org/10.48550/arxiv.2301.07841,
   doi       = {10.48550/ARXIV.2301.07841},
   url       = {https://arxiv.org/abs/2301.07841},
@@ -410,6 +412,7 @@
   month     = {1},
   copyright = {arXiv.org perpetual, non-exclusive license}
 }
+
 @article{https://doi.org/10.48550/arxiv.2301.05752,
   doi       = {10.48550/ARXIV.2301.05752},
   url       = {https://arxiv.org/abs/2301.05752},
@@ -421,6 +424,7 @@
   month     = {1},
   copyright = {Creative Commons Attribution 4.0 International}
 }
+
 @article{PhysRevD.107.023007,
   title = {Trapped-ion quantum simulation of collective neutrino oscillations},
   author = {Amitrano, Valentina and Roggero, Alessandro and Luchi, Piero and Turro, Francesco and Vespucci, Luca and Pederiva, Francesco},
@@ -430,7 +434,7 @@
   pages = {023007},
   numpages = {15},
   year = {2023},
-  month = {Jan},
+  month = {1},
   publisher = {American Physical Society},
   doi = {10.1103/PhysRevD.107.023007},
   url = {https://link.aps.org/doi/10.1103/PhysRevD.107.023007}


### PR DESCRIPTION
Included new publications citations for Quantinuum Hardware for Jan 2023.